### PR TITLE
docker: use Ubuntu LTS

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10
+FROM ubuntu:latest
 
 ENV NODE_VERSION v18.12.0
 ENV NVM_DIR /usr/src/.nvm


### PR DESCRIPTION
According to docs, `latest` tags will point to most modern LTS version

<img width="679" alt="CleanShot 2023-05-09 at 01 01 12@2x" src="https://user-images.githubusercontent.com/2096101/236955519-5dc3a7a7-636a-4c94-9ccc-0678f5ee1ae6.png">

<img width="773" alt="CleanShot 2023-05-09 at 01 01 57@2x" src="https://user-images.githubusercontent.com/2096101/236955610-a223baad-1e25-4d52-b41d-968a87dec827.png">

